### PR TITLE
Fixing duplicate imports for serde

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@
 //! println!("{:?}", token);
 //! ```
 
-use serde::Serialize;
 use serde_derive::{Deserialize, Serialize};
 use serde_json as json;
 
@@ -139,7 +138,7 @@ impl Claims {
     }
 }
 
-impl<T: Serialize> jws::Token<T> {
+impl<T: serde::Serialize> jws::Token<T> {
     /// Validate claims with the specific config.
     pub fn validate_claims(&self, config: &ValidationConfig) -> Result<(), Error> {
         let payload = json::to_value(&self.payload)?;


### PR DESCRIPTION
Both imports are producing an error while building with jwts as a dependency :
```
   |
78 | use serde::Serialize;
   |     ---------------- previous import of the macro `Serialize` here
79 | use serde_derive::{Deserialize, Serialize};
   |                                 ^^^^^^^^^ `Serialize` reimported here
   |
   = note: `Serialize` must be defined only once in the macro namespace of this module
```